### PR TITLE
Evitar usar `única forma` também no subtítulo

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -1,5 +1,5 @@
 title: Artesanato de Software
-description: "A única forma de fazer rápido é fazer bem feito"
+description: "A melhor forma de fazer rápido é fazer bem feito"
 logo: hephaestus.png
 disqus_shortnameg:
 # Assign a default image for your site's header and footer


### PR DESCRIPTION
Ao fazer uma revisão rápida notei que nosso subtítulo tem uma expressão muito absolutista. Acho melhor usarmos a expressão `melhor forma` ao invés de `única forma`.