### PR TITLE
Adicionar link para o Meetup no rodapé

### DIFF
--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -48,6 +48,11 @@
                     <i class="icon-github"></i>
                 </a>
             </li>{% endif %}
+            <li>
+                <a href="http://www.meetup.com/Comunidade-de-Artesanato-de-Software-de-Joinville/" data-toggle="tooltip" title="Meetup" target="_blank">
+                    <i class="icon-group"></i>
+                </a>
+            </li>
         </ul>
             <p class="copy-text">
                 <a href="{{ site.url }}/about/">{{ site.owner.name }}</a> <a rel="license" href="http://creativecommons.org/licenses/by/4.0/"><img alt="Licença Creative Commons" style="border-width:0" src="https://i.creativecommons.org/l/by/4.0/88x31.png" /></a><br />Este trabalho está licenciado com uma Licença <a rel="license" href="http://creativecommons.org/licenses/by/4.0/">Creative Commons - Atribuição  4.0 Internacional</a>.


### PR DESCRIPTION
Acho legal ter o link da comunidade no Meetup para que os visitantes saibam quem está por trás do site